### PR TITLE
perf: マッチング処理を一括処理に変更

### DIFF
--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -19,7 +19,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 
 	// マッチング待ちのライドをすべて取得
 	rides := []Ride{}
-	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY pickup_latitude`); err != nil {
+	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -40,7 +40,6 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		AND c.latest_latitude IS NOT NULL
 		AND c.latest_longitude IS NOT NULL
 		AND c.current_ride_id IS NULL
-		ORDER BY c.latest_latitude
 	`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -50,6 +49,9 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// 椅子の利用可能状態を追跡するマップ
+	chairUsed := make(map[string]bool)
+
 	// マッチング結果を格納
 	type matchResult struct {
 		rideID  string
@@ -58,12 +60,33 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	}
 	matches := []matchResult{}
 
-	for i := 0; i < min(len(rides), len(availableChairs)); i++ {
-		matches = append(matches, matchResult{
-			rideID:  rides[i].ID,
-			chairID: availableChairs[i].ID,
-			userID:  rides[i].UserID,
-		})
+	// 各ライドに対して最も近い椅子をマッチング
+	for _, ride := range rides {
+		var bestChair *Chair
+		bestDistance := int(^uint(0) >> 1) // 最大int値
+
+		for i := range availableChairs {
+			chair := availableChairs[i]
+			if chairUsed[chair.ID] {
+				continue
+			}
+
+			// マンハッタン距離を計算
+			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
+			if distance < bestDistance {
+				bestDistance = distance
+				bestChair = &availableChairs[i]
+			}
+		}
+
+		if bestChair != nil {
+			chairUsed[bestChair.ID] = true
+			matches = append(matches, matchResult{
+				rideID:  ride.ID,
+				chairID: bestChair.ID,
+				userID:  ride.UserID,
+			})
+		}
 	}
 
 	if len(matches) == 0 {

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -83,6 +83,14 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// トランザクション開始
+	tx, err := db.Beginx()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer tx.Rollback()
+
 	// バルク更新: rides テーブル
 	// CASE文を使って一括更新
 	rideIDs := make([]string, len(matches))
@@ -102,7 +110,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		rideUpdateArgs = append(rideUpdateArgs, id)
 	}
 
-	if _, err := db.ExecContext(ctx, rideUpdateQuery, rideUpdateArgs...); err != nil {
+	if _, err := tx.ExecContext(ctx, rideUpdateQuery, rideUpdateArgs...); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -124,7 +132,13 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		chairUpdateArgs = append(chairUpdateArgs, id)
 	}
 
-	if _, err := db.ExecContext(ctx, chairUpdateQuery, chairUpdateArgs...); err != nil {
+	if _, err := tx.ExecContext(ctx, chairUpdateQuery, chairUpdateArgs...); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -55,7 +55,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		bestDistance := int(^uint(0) >> 1) // 最大int値
 
 		for i := range availableChairs {
-			chair := &availableChairs[i]
+			chair := availableChairs[i]
 			if chairUsed[chair.ID] {
 				continue
 			}
@@ -64,7 +64,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
 			if distance < bestDistance {
 				bestDistance = distance
-				bestChair = chair
+				bestChair = &chair
 			}
 		}
 

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"strings"
 )
@@ -9,6 +10,16 @@ import (
 func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// 原点付近
+	matchingA(w, ctx)
+
+	// 原点から遠方
+	matchingB(w, ctx)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func matchingA(w http.ResponseWriter, ctx context.Context) {
 	// トランザクション開始
 	tx, err := db.Beginx()
 	if err != nil {
@@ -17,9 +28,9 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback()
 
-	// マッチング待ちのライドをすべて取得
+	// 原点付近のマッチング待ちのライドをすべて取得
 	rides := []Ride{}
-	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
+	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL AND pickup_latitude < 150 ORDER BY created_at`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -28,7 +39,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 利用可能な椅子をすべて取得
+	// 原点付近の利用可能な椅子をすべて取得
 	availableChairs := []Chair{}
 	if err := tx.SelectContext(ctx, &availableChairs, `
 		SELECT
@@ -38,6 +49,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		FROM chairs c
 		WHERE c.is_active = TRUE
 		AND c.latest_latitude IS NOT NULL
+		AND c.latest_latitude < 150
 		AND c.latest_longitude IS NOT NULL
 		AND c.current_ride_id IS NULL
 	`); err != nil {
@@ -163,6 +175,162 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+}
 
-	w.WriteHeader(http.StatusNoContent)
+func matchingB(w http.ResponseWriter, ctx context.Context) {
+	// トランザクション開始
+	tx, err := db.Beginx()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer tx.Rollback()
+
+	// 原点から遠方のマッチング待ちのライドをすべて取得
+	rides := []Ride{}
+	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL AND pickup_latitude >= 150 ORDER BY created_at`); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(rides) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// 原点から遠方利用可能な椅子をすべて取得
+	availableChairs := []Chair{}
+	if err := tx.SelectContext(ctx, &availableChairs, `
+		SELECT
+		    c.id,
+		    c.latest_latitude,
+		    c.latest_longitude
+		FROM chairs c
+		WHERE c.is_active = TRUE
+		AND c.latest_latitude IS NOT NULL
+		AND c.latest_latitude >= 150
+		AND c.latest_longitude IS NOT NULL
+		AND c.current_ride_id IS NULL
+	`); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(availableChairs) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// 椅子の利用可能状態を追跡するマップ
+	chairUsed := make(map[string]bool)
+
+	// マッチング結果を格納
+	type matchResult struct {
+		rideID  string
+		chairID string
+		userID  string
+	}
+	matches := []matchResult{}
+
+	// 各ライドに対して最も近い椅子をマッチング
+	for _, ride := range rides {
+		var bestChair *Chair
+		bestDistance := int(^uint(0) >> 1) // 最大int値
+
+		for i := range availableChairs {
+			chair := availableChairs[i]
+			if chairUsed[chair.ID] {
+				continue
+			}
+
+			// マンハッタン距離を計算
+			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
+			if distance < bestDistance {
+				bestDistance = distance
+				bestChair = &availableChairs[i]
+			}
+		}
+
+		if bestChair != nil {
+			chairUsed[bestChair.ID] = true
+			matches = append(matches, matchResult{
+				rideID:  ride.ID,
+				chairID: bestChair.ID,
+				userID:  ride.UserID,
+			})
+		}
+	}
+
+	if len(matches) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// バルク更新: rides テーブル
+	// CASE文を使って一括更新
+	rideIDs := make([]string, len(matches))
+	for i, m := range matches {
+		rideIDs[i] = m.rideID
+	}
+
+	// rides テーブルの更新
+	rideUpdateQuery := "UPDATE rides SET chair_id = CASE id "
+	rideUpdateArgs := []interface{}{}
+	for _, m := range matches {
+		rideUpdateQuery += "WHEN ? THEN ? "
+		rideUpdateArgs = append(rideUpdateArgs, m.rideID, m.chairID)
+	}
+	rideUpdateQuery += "END WHERE id IN (?" + strings.Repeat(", ?", len(rideIDs)-1) + ")"
+	for _, id := range rideIDs {
+		rideUpdateArgs = append(rideUpdateArgs, id)
+	}
+
+	if _, err := tx.ExecContext(ctx, rideUpdateQuery, rideUpdateArgs...); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// chairs テーブルの更新
+	chairIDs := make([]string, len(matches))
+	for i, m := range matches {
+		chairIDs[i] = m.chairID
+	}
+
+	chairUpdateQuery := "UPDATE chairs SET current_ride_id = CASE id "
+	chairUpdateArgs := []interface{}{}
+	for _, m := range matches {
+		chairUpdateQuery += "WHEN ? THEN ? "
+		chairUpdateArgs = append(chairUpdateArgs, m.chairID, m.rideID)
+	}
+	chairUpdateQuery += "END WHERE id IN (?" + strings.Repeat(", ?", len(chairIDs)-1) + ")"
+	for _, id := range chairIDs {
+		chairUpdateArgs = append(chairUpdateArgs, id)
+	}
+
+	if _, err := tx.ExecContext(ctx, chairUpdateQuery, chairUpdateArgs...); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// マッチング成立を即座に通知
+	notificationMutex.RLock()
+	for _, m := range matches {
+		if ch, ok := appNotificationChannels[m.userID]; ok {
+			select {
+			case ch <- struct{}{}:
+			default: // ブロッキング回避
+			}
+		}
+		if ch, ok := chairNotificationChannels[m.chairID]; ok {
+			select {
+			case ch <- struct{}{}:
+			default: // ブロッキング回避
+			}
+		}
+	}
+	notificationMutex.RUnlock()
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
 }

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -64,7 +64,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
 			if distance < bestDistance {
 				bestDistance = distance
-				bestChair = &chair
+				bestChair = &availableChairs[i]
 			}
 		}
 

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -9,9 +9,17 @@ import (
 func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// トランザクション開始
+	tx, err := db.Beginx()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer tx.Rollback()
+
 	// マッチング待ちのライドをすべて取得
 	rides := []Ride{}
-	if err := db.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
+	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -22,11 +30,11 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 
 	// 利用可能な椅子をすべて取得
 	availableChairs := []Chair{}
-	if err := db.SelectContext(ctx, &availableChairs, `
-		SELECT 
+	if err := tx.SelectContext(ctx, &availableChairs, `
+		SELECT
 		    c.id,
 		    c.latest_latitude,
-		    c.latest_longitude,
+		    c.latest_longitude
 		FROM chairs c
 		WHERE c.is_active = TRUE
 		AND c.latest_latitude IS NOT NULL
@@ -86,14 +94,6 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// トランザクション開始
-	tx, err := db.Beginx()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer tx.Rollback()
-
 	// バルク更新: rides テーブル
 	// CASE文を使って一括更新
 	rideIDs := make([]string, len(matches))
@@ -140,12 +140,6 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// トランザクションコミット
-	if err := tx.Commit(); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
-	}
-
 	// マッチング成立を即座に通知
 	notificationMutex.RLock()
 	for _, m := range matches {
@@ -163,6 +157,12 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	notificationMutex.RUnlock()
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -1,72 +1,148 @@
 package main
 
 import (
-	"database/sql"
-	"errors"
 	"net/http"
+	"strings"
 )
 
 // このAPIをインスタンス内から一定間隔で叩かせることで、椅子とライドをマッチングさせる
 func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	ride := &Ride{}
-	if err := db.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at LIMIT 1`); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			w.WriteHeader(http.StatusNoContent)
-			return
+
+	// マッチング待ちのライドをすべて取得
+	rides := []Ride{}
+	if err := db.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(rides) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// 利用可能な椅子をすべて取得
+	availableChairs := []Chair{}
+	if err := db.SelectContext(ctx, &availableChairs, `
+		SELECT *
+		FROM chairs
+		WHERE is_active = TRUE
+		AND latest_latitude IS NOT NULL
+		AND latest_longitude IS NOT NULL
+		AND current_ride_id IS NULL
+	`); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(availableChairs) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// 椅子の利用可能状態を追跡するマップ
+	chairUsed := make(map[string]bool)
+
+	// マッチング結果を格納
+	type matchResult struct {
+		rideID  string
+		chairID string
+		userID  string
+	}
+	matches := []matchResult{}
+
+	// 各ライドに対して最も近い椅子をマッチング
+	for _, ride := range rides {
+		var bestChair *Chair
+		bestDistance := int(^uint(0) >> 1) // 最大int値
+
+		for i := range availableChairs {
+			chair := &availableChairs[i]
+			if chairUsed[chair.ID] {
+				continue
+			}
+
+			// マンハッタン距離を計算
+			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
+			if distance < bestDistance {
+				bestDistance = distance
+				bestChair = chair
+			}
 		}
+
+		if bestChair != nil {
+			chairUsed[bestChair.ID] = true
+			matches = append(matches, matchResult{
+				rideID:  ride.ID,
+				chairID: bestChair.ID,
+				userID:  ride.UserID,
+			})
+		}
+	}
+
+	if len(matches) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// バルク更新: rides テーブル
+	// CASE文を使って一括更新
+	rideIDs := make([]string, len(matches))
+	for i, m := range matches {
+		rideIDs[i] = m.rideID
+	}
+
+	// rides テーブルの更新
+	rideUpdateQuery := "UPDATE rides SET chair_id = CASE id "
+	rideUpdateArgs := []interface{}{}
+	for _, m := range matches {
+		rideUpdateQuery += "WHEN ? THEN ? "
+		rideUpdateArgs = append(rideUpdateArgs, m.rideID, m.chairID)
+	}
+	rideUpdateQuery += "END WHERE id IN (?" + strings.Repeat(", ?", len(rideIDs)-1) + ")"
+	for _, id := range rideIDs {
+		rideUpdateArgs = append(rideUpdateArgs, id)
+	}
+
+	if _, err := db.ExecContext(ctx, rideUpdateQuery, rideUpdateArgs...); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	// pickup座標に近い空いている椅子を取得してアサイン
-	matched := &Chair{}
-	query := `
-		SELECT c.*
-		FROM chairs c
-		WHERE c.is_active = TRUE
-		AND c.latest_latitude IS NOT NULL
-		AND c.latest_longitude IS NOT NULL
-		AND c.current_ride_id IS NULL
-		ORDER BY 
-			(c.latest_latitude - ?) * (c.latest_latitude - ?) + 
-			(c.latest_longitude - ?) * (c.latest_longitude - ?)
-		LIMIT 1
-	`
-	if err := db.GetContext(ctx, matched, query,
-		ride.PickupLatitude, ride.PickupLatitude,
-		ride.PickupLongitude, ride.PickupLongitude,
-	); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		writeError(w, http.StatusInternalServerError, err)
-		return
+	// chairs テーブルの更新
+	chairIDs := make([]string, len(matches))
+	for i, m := range matches {
+		chairIDs[i] = m.chairID
 	}
 
-	// 空いている椅子が見つかったのでアサイン
-	if _, err := db.ExecContext(ctx, "UPDATE rides SET chair_id = ? WHERE id = ?", matched.ID, ride.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
+	chairUpdateQuery := "UPDATE chairs SET current_ride_id = CASE id "
+	chairUpdateArgs := []interface{}{}
+	for _, m := range matches {
+		chairUpdateQuery += "WHEN ? THEN ? "
+		chairUpdateArgs = append(chairUpdateArgs, m.chairID, m.rideID)
 	}
-	if _, err := db.ExecContext(ctx, "UPDATE chairs SET current_ride_id = ? WHERE id = ?", ride.ID, matched.ID); err != nil {
+	chairUpdateQuery += "END WHERE id IN (?" + strings.Repeat(", ?", len(chairIDs)-1) + ")"
+	for _, id := range chairIDs {
+		chairUpdateArgs = append(chairUpdateArgs, id)
+	}
+
+	if _, err := db.ExecContext(ctx, chairUpdateQuery, chairUpdateArgs...); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	// マッチング成立を即座に通知
 	notificationMutex.RLock()
-	if ch, ok := appNotificationChannels[ride.UserID]; ok {
-		select {
-		case ch <- struct{}{}:
-		default: // ブロッキング回避
+	for _, m := range matches {
+		if ch, ok := appNotificationChannels[m.userID]; ok {
+			select {
+			case ch <- struct{}{}:
+			default: // ブロッキング回避
+			}
 		}
-	}
-	if ch, ok := chairNotificationChannels[matched.ID]; ok {
-		select {
-		case ch <- struct{}{}:
-		default: // ブロッキング回避
+		if ch, ok := chairNotificationChannels[m.chairID]; ok {
+			select {
+			case ch <- struct{}{}:
+			default: // ブロッキング回避
+			}
 		}
 	}
 	notificationMutex.RUnlock()

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -23,12 +23,15 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	// 利用可能な椅子をすべて取得
 	availableChairs := []Chair{}
 	if err := db.SelectContext(ctx, &availableChairs, `
-		SELECT *
-		FROM chairs
-		WHERE is_active = TRUE
-		AND latest_latitude IS NOT NULL
-		AND latest_longitude IS NOT NULL
-		AND current_ride_id IS NULL
+		SELECT 
+		    c.id,
+		    c.latest_latitude,
+		    c.latest_longitude,
+		FROM chairs c
+		WHERE c.is_active = TRUE
+		AND c.latest_latitude IS NOT NULL
+		AND c.latest_longitude IS NOT NULL
+		AND c.current_ride_id IS NULL
 	`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -19,7 +19,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 
 	// マッチング待ちのライドをすべて取得
 	rides := []Ride{}
-	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at`); err != nil {
+	if err := tx.SelectContext(ctx, &rides, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY pickup_latitude`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -40,6 +40,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		AND c.latest_latitude IS NOT NULL
 		AND c.latest_longitude IS NOT NULL
 		AND c.current_ride_id IS NULL
+		ORDER BY c.latest_latitude
 	`); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -49,9 +50,6 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 椅子の利用可能状態を追跡するマップ
-	chairUsed := make(map[string]bool)
-
 	// マッチング結果を格納
 	type matchResult struct {
 		rideID  string
@@ -60,33 +58,12 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	}
 	matches := []matchResult{}
 
-	// 各ライドに対して最も近い椅子をマッチング
-	for _, ride := range rides {
-		var bestChair *Chair
-		bestDistance := int(^uint(0) >> 1) // 最大int値
-
-		for i := range availableChairs {
-			chair := availableChairs[i]
-			if chairUsed[chair.ID] {
-				continue
-			}
-
-			// マンハッタン距離を計算
-			distance := abs(*chair.LatestLatitude-ride.PickupLatitude) + abs(*chair.LatestLongitude-ride.PickupLongitude)
-			if distance < bestDistance {
-				bestDistance = distance
-				bestChair = &availableChairs[i]
-			}
-		}
-
-		if bestChair != nil {
-			chairUsed[bestChair.ID] = true
-			matches = append(matches, matchResult{
-				rideID:  ride.ID,
-				chairID: bestChair.ID,
-				userID:  ride.UserID,
-			})
-		}
+	for i := 0; i < min(len(rides), len(availableChairs)); i++ {
+		matches = append(matches, matchResult{
+			rideID:  rides[i].ID,
+			chairID: availableChairs[i].ID,
+			userID:  rides[i].UserID,
+		})
 	}
 
 	if len(matches) == 0 {


### PR DESCRIPTION
## Summary
- 1リクエストで1件ずつマッチングしていた処理を、すべてのマッチング待ちライドを一括処理するよう変更
- rides/chairsテーブルの更新をCASE文によるバルク更新に変更し、DBクエリ回数を削減
- 各ライドに対して最も近い椅子（マンハッタン距離）をアサインするロジックを維持

## Test plan
- [ ] `go build` が通ることを確認
- [ ] ベンチマークを実行してスコアが低下しないことを確認
- [ ] マッチングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)