### PR TITLE
feat: chair_locationsをオンメモリキャッシュ化し真のバルクINSERTに変更

### DIFF
--- a/go/chair_handlers.go
+++ b/go/chair_handlers.go
@@ -130,6 +130,28 @@ func chairPostCoordinate(w http.ResponseWriter, r *http.Request) {
 		CreatedAt: now,
 	}
 
+	// メモリキャッシュから前回位置を取得して距離を計算
+	prevLocation := getChairLatestLocation(chair.ID)
+	distance := 0
+	if prevLocation != nil {
+		distance = abs(req.Latitude-prevLocation.Latitude) + abs(req.Longitude-prevLocation.Longitude)
+	}
+
+	// chairsテーブルを即座に更新（トリガーの代わり）
+	if _, err := db.ExecContext(ctx, `UPDATE chairs SET 
+		latest_latitude = ?, 
+		latest_longitude = ?, 
+		latest_location_updated_at = ?,
+		total_distance = total_distance + ?
+	WHERE id = ?`, req.Latitude, req.Longitude, now, distance, chair.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// メモリキャッシュを更新
+	setChairLatestLocation(chair.ID, &location)
+
+	// chair_locationsバッファに追加
 	chairLocationBufferMutex.Lock()
 	chairLocationBuffer = append(chairLocationBuffer, location)
 	chairLocationBufferMutex.Unlock()

--- a/go/main.go
+++ b/go/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,12 @@ var (
 	chairCurrentRideCacheMutex sync.RWMutex
 )
 
+// 椅子の最新位置キャッシュ (chair_id -> ChairLocation)
+var (
+	chairLatestLocationCache      = make(map[string]*ChairLocation)
+	chairLatestLocationCacheMutex sync.RWMutex
+)
+
 func getChairByAccessToken(token string) (*Chair, bool) {
 	chairCacheMutex.RLock()
 	defer chairCacheMutex.RUnlock()
@@ -81,6 +88,57 @@ func setChairCurrentRideID(chairID string, rideID string) {
 	chairCurrentRideCacheMutex.Lock()
 	defer chairCurrentRideCacheMutex.Unlock()
 	chairCurrentRideCache[chairID] = rideID
+}
+
+// 椅子の最新位置を取得
+func getChairLatestLocation(chairID string) *ChairLocation {
+	chairLatestLocationCacheMutex.RLock()
+	defer chairLatestLocationCacheMutex.RUnlock()
+	return chairLatestLocationCache[chairID]
+}
+
+// 椅子の最新位置を設定
+func setChairLatestLocation(chairID string, location *ChairLocation) {
+	chairLatestLocationCacheMutex.Lock()
+	defer chairLatestLocationCacheMutex.Unlock()
+	chairLatestLocationCache[chairID] = location
+}
+
+// 椅子の最新位置キャッシュを初期化（DBから読み込み）
+func initChairLatestLocationCache() {
+	chairLatestLocationCacheMutex.Lock()
+	defer chairLatestLocationCacheMutex.Unlock()
+
+	// キャッシュをクリア
+	chairLatestLocationCache = make(map[string]*ChairLocation)
+
+	// chairsテーブルから最新位置を持つ椅子を取得
+	type chairLocation struct {
+		ID                      string     `db:"id"`
+		LatestLatitude          *int       `db:"latest_latitude"`
+		LatestLongitude         *int       `db:"latest_longitude"`
+		LatestLocationUpdatedAt *time.Time `db:"latest_location_updated_at"`
+	}
+	chairs := []chairLocation{}
+	if err := db.Select(&chairs, "SELECT id, latest_latitude, latest_longitude, latest_location_updated_at FROM chairs WHERE latest_latitude IS NOT NULL"); err != nil {
+		slog.Error("failed to load chair locations", "error", err)
+		return
+	}
+
+	for _, c := range chairs {
+		if c.LatestLatitude != nil && c.LatestLongitude != nil {
+			loc := &ChairLocation{
+				ChairID:   c.ID,
+				Latitude:  *c.LatestLatitude,
+				Longitude: *c.LatestLongitude,
+			}
+			if c.LatestLocationUpdatedAt != nil {
+				loc.CreatedAt = *c.LatestLocationUpdatedAt
+			}
+			chairLatestLocationCache[c.ID] = loc
+		}
+	}
+	slog.Info("chair location cache initialized", "count", len(chairLatestLocationCache))
 }
 
 // INSERT後にキャッシュに追加
@@ -236,6 +294,9 @@ func setup() http.Handler {
 	pproteinHandler := integration.NewDebugHandler()
 	go http.ListenAndServe(":3000", pproteinHandler)
 
+	// 椅子の最新位置キャッシュを初期化
+	initChairLatestLocationCache()
+
 	// chair_locations のバルクインサート用goroutineを起動
 	go bulkInsertChairLocations()
 
@@ -296,6 +357,9 @@ func postInitialize(w http.ResponseWriter, r *http.Request) {
 	chairCurrentRideCacheMutex.Lock()
 	chairCurrentRideCache = make(map[string]string)
 	chairCurrentRideCacheMutex.Unlock()
+
+	// 椅子の最新位置キャッシュを初期化（DBから読み込み）
+	initChairLatestLocationCache()
 
 	go func() {
 		if _, err := http.Get("http://172.31.14.32:9000/api/group/collect"); err != nil {
@@ -378,9 +442,15 @@ func insertChairLocationsBulk(locations []ChairLocation) {
 		return
 	}
 
-	// sqlx.NamedExecを使ってバルクインサート
-	query := `INSERT INTO chair_locations (id, chair_id, latitude, longitude, created_at) VALUES (:id, :chair_id, :latitude, :longitude, :created_at)`
-	_, err := db.NamedExec(query, locations)
+	// 真のバルクインサート: INSERT INTO ... VALUES (...), (...), ...
+	valueStrings := make([]string, 0, len(locations))
+	valueArgs := make([]interface{}, 0, len(locations)*5)
+	for _, loc := range locations {
+		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?)")
+		valueArgs = append(valueArgs, loc.ID, loc.ChairID, loc.Latitude, loc.Longitude, loc.CreatedAt)
+	}
+	query := "INSERT INTO chair_locations (id, chair_id, latitude, longitude, created_at) VALUES " + strings.Join(valueStrings, ",")
+	_, err := db.Exec(query, valueArgs...)
 	if err != nil {
 		slog.Error("bulk insert chair_locations failed", "error", err, "count", len(locations))
 	}

--- a/sql/7-drop-chair-location-trigger.sql
+++ b/sql/7-drop-chair-location-trigger.sql
@@ -1,0 +1,4 @@
+-- chair_locationsのINSERTトリガーを廃止
+-- アプリケーション側でchairsテーブルの更新を行うため、トリガーは不要
+DROP TRIGGER IF EXISTS trg_chair_locations_after_insert;
+

--- a/sql/init.sh
+++ b/sql/init.sh
@@ -53,3 +53,9 @@ mysql -u"$ISUCON_DB_USER" \
 		--host "$ISUCON_DB_HOST" \
 		--port "$ISUCON_DB_PORT" \
 		"$ISUCON_DB_NAME" < 6-add-current-ride-id.sql
+
+mysql -u"$ISUCON_DB_USER" \
+		-p"$ISUCON_DB_PASSWORD" \
+		--host "$ISUCON_DB_HOST" \
+		--port "$ISUCON_DB_PORT" \
+		"$ISUCON_DB_NAME" < 7-drop-chair-location-trigger.sql


### PR DESCRIPTION
- 椅子の最新位置をメモリキャッシュに保持
- DBトリガーを廃止し、アプリケーション側でchairsテーブルを即時更新
- insertChairLocationsBulkを真のバルクINSERT形式に変更
- 起動時・リセット時にDBからキャッシュを初期化