### PR TITLE
マッチング処理を原点付近と遠方で分離

### DIFF
--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -9,8 +10,16 @@ import (
 // このAPIをインスタンス内から一定間隔で叩かせることで、椅子とライドをマッチングさせる
 func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	matchingAroundOrigin(w, ctx)
+	matchingFarFromOrigin(w, ctx)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func matchingAroundOrigin(w http.ResponseWriter, ctx context.Context) {
 	ride := &Ride{}
-	if err := db.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at LIMIT 1`); err != nil {
+	if err := db.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id IS NULL AND pickup_latitude <= 150 ORDER BY created_at LIMIT 1`); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -26,6 +35,7 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		FROM chairs c
 		WHERE c.is_active = TRUE
 		AND c.latest_latitude IS NOT NULL
+		AND c.latest_latitude <= 150
 		AND c.latest_longitude IS NOT NULL
 		AND c.current_ride_id IS NULL
 		ORDER BY 
@@ -74,5 +84,72 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 	}
 	notificationMutex.RUnlock()
 
-	w.WriteHeader(http.StatusNoContent)
+}
+
+func matchingFarFromOrigin(w http.ResponseWriter, ctx context.Context) {
+	ride := &Ride{}
+	if err := db.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id IS NULL AND pickup_latitude > 150 ORDER BY created_at LIMIT 1`); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// pickup座標に近い空いている椅子を取得してアサイン
+	matched := &Chair{}
+	query := `
+		SELECT c.*
+		FROM chairs c
+		WHERE c.is_active = TRUE
+		AND c.latest_latitude IS NOT NULL
+		AND c.latest_latitude > 150
+		AND c.latest_longitude IS NOT NULL
+		AND c.current_ride_id IS NULL
+		ORDER BY 
+			(c.latest_latitude - ?) * (c.latest_latitude - ?) + 
+			(c.latest_longitude - ?) * (c.latest_longitude - ?)
+		LIMIT 1
+	`
+	if err := db.GetContext(ctx, matched, query,
+		ride.PickupLatitude, ride.PickupLatitude,
+		ride.PickupLongitude, ride.PickupLongitude,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// 空いている椅子が見つかったのでアサイン
+	if _, err := db.ExecContext(ctx, "UPDATE rides SET chair_id = ? WHERE id = ?", matched.ID, ride.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if _, err := db.ExecContext(ctx, "UPDATE chairs SET current_ride_id = ? WHERE id = ?", ride.ID, matched.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// キャッシュを更新
+	setChairCurrentRideID(matched.ID, ride.ID)
+
+	// マッチング成立を即座に通知
+	notificationMutex.RLock()
+	if ch, ok := appNotificationChannels[ride.UserID]; ok {
+		select {
+		case ch <- struct{}{}:
+		default: // ブロッキング回避
+		}
+	}
+	if ch, ok := chairNotificationChannels[matched.ID]; ok {
+		select {
+		case ch <- struct{}{}:
+		default: // ブロッキング回避
+		}
+	}
+	notificationMutex.RUnlock()
 }


### PR DESCRIPTION
#22

座標を調べた結果はっきりと 2 エリアに別れたので、エリアごとにマッチングを行うように修正。

<img width="1280" height="408" alt="image" src="https://github.com/user-attachments/assets/55830549-b53b-4902-b55e-ecc5908d0272" />
