### PR TITLE
イベント駆動マッチング

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ start-services:
 	sudo systemctl daemon-reload
 	ssh isucon-s2 "sudo systemctl start mysql"
 	sudo systemctl start $(APPNAME)
-	sudo systemctl start isuride-matcher.service 
 	sudo systemctl start nginx
 
 start-bench:

--- a/go/app_handlers.go
+++ b/go/app_handlers.go
@@ -427,6 +427,8 @@ func appPostRides(w http.ResponseWriter, r *http.Request) {
 		CreatedAt: rideStatusCreatedAt,
 	})
 
+	matchingChan <- struct{}{}
+
 	writeJSON(w, http.StatusAccepted, &appPostRidesResponse{
 		RideID: rideID,
 		Fare:   fare,

--- a/go/internal_handlers.go
+++ b/go/internal_handlers.go
@@ -1,25 +1,22 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
-	"net/http"
+	"log/slog"
 )
 
-// このAPIをインスタンス内から一定間隔で叩かせることで、椅子とライドをマッチングさせる
-func internalGetMatching(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+func runMatching(ctx context.Context) {
 	ride := &Ride{}
 	if err := db.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at LIMIT 1`); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		slog.Error("failed to get ride for matching", "error", err)
 		return
 	}
 
-	// pickup座標に近い空いている椅子を取得してアサイン
 	matched := &Chair{}
 	query := `
 		SELECT c.*
@@ -38,41 +35,35 @@ func internalGetMatching(w http.ResponseWriter, r *http.Request) {
 		ride.PickupLongitude, ride.PickupLongitude,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		slog.Error("failed to get matched chair", "error", err)
 		return
 	}
 
-	// 空いている椅子が見つかったのでアサイン
 	if _, err := db.ExecContext(ctx, "UPDATE rides SET chair_id = ? WHERE id = ?", matched.ID, ride.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		slog.Error("failed to update ride with chair_id", "error", err)
 		return
 	}
 	if _, err := db.ExecContext(ctx, "UPDATE chairs SET current_ride_id = ? WHERE id = ?", ride.ID, matched.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		slog.Error("failed to update chair with current_ride_id", "error", err)
 		return
 	}
 
-	// キャッシュを更新
 	setChairCurrentRideID(matched.ID, ride.ID)
 
-	// マッチング成立を即座に通知
 	notificationMutex.RLock()
 	if ch, ok := appNotificationChannels[ride.UserID]; ok {
 		select {
 		case ch <- struct{}{}:
-		default: // ブロッキング回避
+		default:
 		}
 	}
 	if ch, ok := chairNotificationChannels[matched.ID]; ok {
 		select {
 		case ch <- struct{}{}:
-		default: // ブロッキング回避
+		default:
 		}
 	}
 	notificationMutex.RUnlock()
-
-	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/main.go
+++ b/go/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -34,6 +35,10 @@ var (
 var (
 	chairLocationBuffer      = []ChairLocation{}
 	chairLocationBufferMutex sync.Mutex
+)
+
+var (
+	matchingChan = make(chan struct{}, 1000)
 )
 
 // 未送信ステータスのキャッシュ (ride_id -> []RideStatus)
@@ -286,11 +291,6 @@ func setup() http.Handler {
 		authedMux.HandleFunc("POST /api/chair/rides/{ride_id}/status", chairPostRideStatus)
 	}
 
-	// internal handlers
-	{
-		mux.HandleFunc("GET /api/internal/matching", internalGetMatching)
-	}
-
 	pproteinHandler := integration.NewDebugHandler()
 	go http.ListenAndServe(":3000", pproteinHandler)
 
@@ -299,6 +299,8 @@ func setup() http.Handler {
 
 	// chair_locations のバルクインサート用goroutineを起動
 	go bulkInsertChairLocations()
+
+	go matchingWorker()
 
 	return mux
 }
@@ -453,5 +455,12 @@ func insertChairLocationsBulk(locations []ChairLocation) {
 	_, err := db.Exec(query, valueArgs...)
 	if err != nil {
 		slog.Error("bulk insert chair_locations failed", "error", err, "count", len(locations))
+	}
+}
+
+func matchingWorker() {
+	ctx := context.Background()
+	for range matchingChan {
+		runMatching(ctx)
 	}
 }


### PR DESCRIPTION
refs #22 

定期的に未マッチングがあるか探すのではなく、rideがPOSTされたら1回マッチングするように変更する。

参考: https://github.com/okashoi/isucon14-practice-20251109/pull/19
